### PR TITLE
Add “skip” and “only” options for CLI

### DIFF
--- a/bin/phare
+++ b/bin/phare
@@ -4,4 +4,4 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'phare'
 
-Phare::CLI.new(ENV).run
+Phare::CLI.new(ENV, ARGV).run

--- a/lib/phare.rb
+++ b/lib/phare.rb
@@ -1,4 +1,5 @@
 require 'English'
+require 'optparse'
 require 'phare/version'
 
 require 'phare/cli'

--- a/lib/phare/cli.rb
+++ b/lib/phare/cli.rb
@@ -3,9 +3,12 @@ module Phare
   class CLI
     attr_reader :suite
 
-    def initialize(env)
+    def initialize(env, argv)
       @env = env
-      @suite = Phare::CheckSuite.new(Dir.getwd)
+      @argv = argv
+      parse_options
+
+      @suite = Phare::CheckSuite.new(@options)
     end
 
     def run
@@ -30,6 +33,27 @@ module Phare
           exit 1
         end
       end
+    end
+
+    def parse_options
+      @options = { directory: Dir.getwd }
+
+      OptionParser.new do |opts|
+        opts.banner = 'Usage: phare [options]'
+
+        opts.on('--directory', 'The directory in which to run the checks (default is the current directory') do |directory|
+          @options[:directory] = directory
+        end
+
+        opts.on('--skip x,y,z', 'Skip checks') do |checks|
+          @options[:skip] = checks.split(',').map(&:to_sym)
+        end
+
+        opts.on('--only x,y,z', 'Only run the specified checks') do |checks|
+          @options[:only] = checks.split(',').map(&:to_sym)
+        end
+
+      end.parse! @argv
     end
   end
 end

--- a/spec/phare/cli_spec.rb
+++ b/spec/phare/cli_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Phare::CLI do
-  let(:cli) { described_class.new(env) }
+  let(:cli) { described_class.new(env, argv) }
+  let(:argv) { [] }
   let(:run!) { cli.run }
 
   describe :initialize do


### PR DESCRIPTION
It’s now possible to use the `phare` executable with the `--skip` and `--only` options which allows us to specify checks we want to skip or only run specific checks.

``` bash
$ phare --skip jshint # Will not run JSHint
$ phare --only rubocop,jscs # Will only run Rubocop and JSCS
```
