### PR TITLE
Don't run validations for nothing

### DIFF
--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -4,19 +4,33 @@ module Phare
     class JSCS < Check
       attr_reader :config, :path
 
-      def initialize(directory)
+      def initialize(directory, options = {})
         @config = File.expand_path("#{directory}.jscs.json", __FILE__)
         @path = File.expand_path("#{directory}app/assets", __FILE__)
+        @extensions = %w(.js)
+        @options = options
       end
 
       def command
-        "jscs #{@path}"
+        if tree_changed?
+          "jscs #{tree_changes.join(' ')}"
+        else
+          "jscs #{@path}"
+        end
       end
 
     protected
 
-      def should_run?
-        !Phare.system_output('which jscs').empty? && File.exists?(@config) && Dir.exists?(@path)
+      def binary_exists?
+        !Phare.system_output('which jscs').empty?
+      end
+
+      def configuration_exists?
+        File.exists?(@config)
+      end
+
+      def argument_exists?
+        tree_changed? || Dir.exists?(@path)
       end
 
       def print_banner

--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -4,20 +4,34 @@ module Phare
     class JSHint < Check
       attr_reader :config, :path
 
-      def initialize(directory)
+      def initialize(directory, options = {})
         @config = File.expand_path("#{directory}.jshintrc", __FILE__)
         @path = File.expand_path("#{directory}app/assets/javascripts", __FILE__)
         @glob = File.join(@path, '**/*')
+        @extensions = %w(.js .es6.js)
+        @options = options
       end
 
       def command
-        "jshint --config #{@config} --extra-ext .js,.es6.js #{@glob}"
+        if tree_changed?
+          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{tree_changes.join(' ')}"
+        else
+          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@glob}"
+        end
       end
 
     protected
 
-      def should_run?
-        !Phare.system_output('which jshint').empty? && File.exists?(@config) && Dir.exists?(@path)
+      def binary_exists?
+        !Phare.system_output('which jshint').empty?
+      end
+
+      def configuration_exists?
+        File.exists?(@config)
+      end
+
+      def arguments_exists?
+        tree_changed? || Dir.exists?(@path)
       end
 
       def print_banner

--- a/lib/phare/check/rubocop.rb
+++ b/lib/phare/check/rubocop.rb
@@ -2,17 +2,23 @@
 module Phare
   class Check
     class Rubocop < Check
-      def initialize(directory)
+      def initialize(directory, options = {})
         @path = directory
+        @extensions = %w(.rb)
+        @options = options
       end
 
       def command
-        'rubocop'
+        if tree_changed?
+          "rubocop #{tree_changes.join(' ')}"
+        else
+          'rubocop'
+        end
       end
 
     protected
 
-      def should_run?
+      def binary_exists?
         !Phare.system_output('which rubocop').empty?
       end
 

--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -4,18 +4,28 @@ module Phare
     class ScssLint < Check
       attr_reader :path
 
-      def initialize(directory)
+      def initialize(directory, options = {})
         @path = File.expand_path("#{directory}app/assets/stylesheets", __FILE__)
+        @extensions = %w(.css .scss)
+        @options = options
       end
 
       def command
-        "scss-lint #{@path}"
+        if tree_changed?
+          "scss-lint #{tree_changes.join(' ')}"
+        else
+          "scss-lint #{@path}"
+        end
       end
 
     protected
 
-      def should_run?
-        !Phare.system_output('which scss-lint').empty? && Dir.exists?(@path)
+      def binary_exists?
+        !Phare.system_output('which scss-lint').empty?
+      end
+
+      def arguments_exists?
+        tree_changed? || Dir.exists?(@path)
       end
 
       def print_banner

--- a/lib/phare/check_suite.rb
+++ b/lib/phare/check_suite.rb
@@ -34,7 +34,7 @@ module Phare
     def run
       @checks = checks.map do |check|
         check = DEFAULT_CHECKS[check]
-        check.new(@directory).tap(&:run).status
+        check.new(@directory, @options).tap(&:run).status
       end
 
       @status = @checks.find { |status| status > 0 } || 0

--- a/lib/phare/cli.rb
+++ b/lib/phare/cli.rb
@@ -53,6 +53,10 @@ module Phare
           @options[:only] = checks.split(',').map(&:to_sym)
         end
 
+        opts.on('--diff', 'Only run checks on modified files') do
+          @options[:diff] = true
+        end
+
       end.parse! @argv
     end
   end

--- a/spec/phare/check/jshint_spec.rb
+++ b/spec/phare/check/jshint_spec.rb
@@ -29,9 +29,11 @@ describe Phare::Check::JSHint do
     let(:run!) { check.run }
 
     context 'with available JSHint' do
+      let(:command) { check.command }
+
       before do
         expect(check).to receive(:should_run?).and_return(true)
-        expect(Phare).to receive(:system).with(check.command)
+        expect(Phare).to receive(:system).with(command)
         expect(Phare).to receive(:last_exit_status).and_return(jshint_exit_status)
         expect(check).to receive(:print_banner)
       end

--- a/spec/phare/check/rubocop_spec.rb
+++ b/spec/phare/check/rubocop_spec.rb
@@ -21,9 +21,11 @@ describe Phare::Check::Rubocop do
     let(:run!) { check.run }
 
     context 'with available Rubocop' do
+      let(:command) { check.command }
+
       before do
         expect(check).to receive(:should_run?).and_return(true)
-        expect(Phare).to receive(:system).with(check.command)
+        expect(Phare).to receive(:system).with(command)
         expect(Phare).to receive(:last_exit_status).and_return(rubocop_exit_status)
         expect(check).to receive(:print_banner)
       end
@@ -36,6 +38,17 @@ describe Phare::Check::Rubocop do
       context 'without check errors' do
         let(:rubocop_exit_status) { 1337 }
         before { expect(Phare).to receive(:puts).with("Something went wrong. Program exited with #{rubocop_exit_status}.") }
+        it { expect { run! }.to change { check.status }.to(rubocop_exit_status) }
+      end
+
+      context 'with --diff option' do
+        let(:check) { described_class.new('.', diff: true) }
+        let(:files) { ['foo.rb', 'bar.rb'] }
+        let(:command) { "rubocop #{files.join(' ')}" }
+        let(:rubocop_exit_status) { 1337 }
+
+        before { expect(check).to receive(:tree_changes).and_return(files).at_least(:once) }
+
         it { expect { run! }.to change { check.status }.to(rubocop_exit_status) }
       end
     end

--- a/spec/phare/check/scss_lint_spec.rb
+++ b/spec/phare/check/scss_lint_spec.rb
@@ -26,9 +26,11 @@ describe Phare::Check::ScssLint do
     let(:run!) { check.run }
 
     context 'with available ScssLint' do
+      let(:command) { check.command }
+
       before do
         expect(check).to receive(:should_run?).and_return(true)
-        expect(Phare).to receive(:system).with(check.command)
+        expect(Phare).to receive(:system).with(command)
         expect(Phare).to receive(:last_exit_status).and_return(scsslint_exit_status)
         expect(check).to receive(:print_banner)
       end
@@ -42,6 +44,17 @@ describe Phare::Check::ScssLint do
       context 'without check errors' do
         let(:scsslint_exit_status) { 1337 }
         before { expect(Phare).to receive(:puts).with("Something went wrong. Program exited with #{scsslint_exit_status}.") }
+        it { expect { run! }.to change { check.status }.to(scsslint_exit_status) }
+      end
+
+      context 'with --diff option' do
+        let(:check) { described_class.new('.', diff: true) }
+        let(:files) { ['foo.css', 'bar.css.scss'] }
+        let(:command) { "scss-lint #{files.join(' ')}" }
+        let(:scsslint_exit_status) { 1337 }
+
+        before { expect(check).to receive(:tree_changes).and_return(files).at_least(:once) }
+
         it { expect { run! }.to change { check.status }.to(scsslint_exit_status) }
       end
     end


### PR DESCRIPTION
Since some projects have hundreds of files to validates, it is becoming a real waste of time to wait after Rubocop to check every files. Even those who haven't been touched. This is the raw prototype, to present you the basic idea. If that's something we want, I'll apply it to the other validators.

By default, it will behave as usual. To use this feature, add the `--diff` options.

:clock1: :moneybag: 
