### PR TITLE
Bump version to 0.5

### DIFF
--- a/lib/phare/version.rb
+++ b/lib/phare/version.rb
@@ -1,3 +1,3 @@
 module Phare
-  VERSION = '0.4'
+  VERSION = '0.5'
 end


### PR DESCRIPTION
I would want to be able to use is as soon as possible on internal projects so can we release the new version on RubyGems?
