### PR TITLE
Only apply scss-lint to .scss files

### DIFF
--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -6,7 +6,7 @@ module Phare
 
       def initialize(directory, options = {})
         @path = File.expand_path("#{directory}app/assets/stylesheets", __FILE__)
-        @extensions = %w(.css .scss)
+        @extensions = %w(.scss)
         @options = options
 
         super


### PR DESCRIPTION
Sometimes projects (or gems) have `.css` files that _can’t_ be converted to SCSS. We don’t want to check them with `scss-lint`.
