### PR TITLE
Support “SKIP_PHARE” environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ $ bundle binstubs phare
 $ ln -s "`pwd`/bin/phare" .git/hooks/pre-commit
 ```
 
+That way, every time `git commit` is ran, `phare` will be executed and the
+commit will be aborted if there are some errors. However, you can skip this
+check altogether by specifying `SKIP_PHARE=1` before your command.
+
+```bash
+$ git commit -m 'Add stuff'
+$ SKIP_PHARE=1 git commit -m 'Add stuff and I don’t care about Phare'
+```
+
 ### Options
 
 #### Command-line

--- a/lib/phare/cli.rb
+++ b/lib/phare/cli.rb
@@ -11,7 +11,7 @@ module Phare
     end
 
     def run
-      if @env['SKIP_CODE_CHECK']
+      if @env['SKIP_CODE_CHECK'] || @env['SKIP_PHARE']
         Phare.banner 'Skipping code style checking… Really? Well alright then…'
         exit 0
       else

--- a/spec/phare/cli_spec.rb
+++ b/spec/phare/cli_spec.rb
@@ -9,8 +9,13 @@ describe Phare::CLI do
   let(:env) { {} }
 
   describe :run do
-    context 'with code check skipping' do
+    context 'with legacy code check skipping' do
       let(:env) { { 'SKIP_CODE_CHECK' => '1' } }
+      it { expect { run! }.to exit_with_code(0) }
+    end
+
+    context 'with code check skipping' do
+      let(:env) { { 'SKIP_PHARE' => '1' } }
       it { expect { run! }.to exit_with_code(0) }
     end
 


### PR DESCRIPTION
We keep supporting `SKIP_CODE_CHECK` but I thought `SKIP_PHARE` is better :smile:
