### PR TITLE
Improve diff option by only scanning staged files

### DIFF
--- a/lib/phare/git.rb
+++ b/lib/phare/git.rb
@@ -13,7 +13,7 @@ module Phare
       @changes ||= Phare.system_output('git status -s').split("\n").each_with_object([]) do |diff, memo|
         filename = diff.split(' ').last
 
-        if diff =~ /^[^D]{2}/ && @extensions.include?(File.extname(filename))
+        if diff =~ /^[A|M].*/ && @extensions.include?(File.extname(filename))
           memo << filename
         else
           next

--- a/spec/phare/git_spec.rb
+++ b/spec/phare/git_spec.rb
@@ -12,7 +12,7 @@ describe Phare::Git do
       before { expect(git).to receive(:changes).and_return(changes) }
 
       context 'with changes' do
-        let(:changes) { ['foo.rb'] }
+        let(:changes) { %w(foo.rb) }
 
         it { expect(git.changed?).to eq(true) }
       end
@@ -37,31 +37,31 @@ describe Phare::Git do
     context 'with empty tree' do
       let(:tree) { '' }
 
-      it { expect(git.changes).to eq([]) }
+      it { expect(git.changes).to be_empty }
     end
 
     context 'with untracked file' do
       let(:tree) { '?? foo.rb' }
 
-      it { expect(git.changes).to eq(['foo.rb']) }
+      it { expect(git.changes).to be_empty }
     end
 
     context 'with added file' do
       let(:tree) { "A  foo.rb\nAM bar.rb" }
 
-      it { expect(git.changes).to eq(['foo.rb', 'bar.rb']) }
+      it { expect(git.changes).to match_array(%w(foo.rb bar.rb)) }
     end
 
     context 'with modified file' do
-      let(:tree) { "M  foo.rb\nDM bar.rb" }
+      let(:tree) { "M  foo.rb\nDM bar.rb\n M foobar.rb" }
 
-      it { expect(git.changes).to eq(['foo.rb']) }
+      it { expect(git.changes).to match_array(%w(foo.rb)) }
     end
 
     context 'with deleted file' do
-      let(:tree) { " D foo.rb\nMD bar.rb" }
+      let(:tree) { " D foo.rb\nMD bar.rb\n D foobar.rb" }
 
-      it { expect(git.changes).to eq([]) }
+      it { expect(git.changes).to match_array(%w(bar.rb)) }
     end
   end
 end


### PR DESCRIPTION
The `--diff` option is now only checking staged files (added & modified).