### PR TITLE
Handle exclusions from .rubocop.yml in --diff check

### DIFF
--- a/lib/phare/check.rb
+++ b/lib/phare/check.rb
@@ -40,6 +40,10 @@ module Phare
 
   protected
 
+    def files_to_check
+      @tree.changes - excluded_files
+    end
+
     def print_success_message
       Phare.puts('Everything looks good from here!')
     end

--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -23,6 +23,10 @@ module Phare
 
     protected
 
+      def excluded_files
+        [] # TODO: Fetch the exclude list from .jscs.json
+      end
+
       def binary_exists?
         !Phare.system_output('which jscs').empty?
       end

--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -24,6 +24,10 @@ module Phare
 
     protected
 
+      def excluded_files
+        [] # TODO: Fetch the exclude list from .jshintignore
+      end
+
       def binary_exists?
         !Phare.system_output('which jshint').empty?
       end

--- a/lib/phare/check/rubocop.rb
+++ b/lib/phare/check/rubocop.rb
@@ -12,13 +12,23 @@ module Phare
 
       def command
         if @tree.changed?
-          "rubocop #{@tree.changes.join(' ')}"
+          "rubocop #{files_to_check.join(' ')}"
         else
           'rubocop'
         end
       end
 
     protected
+
+      def excluded_files
+        return [] unless configuration_file['AllCops'] && configuration_file['AllCops']['Exclude']
+
+        configuration_file['AllCops']['Exclude'].flat_map { |path| Dir.glob(path) }
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.rubocop.yml') ? YAML::load(File.open('.rubocop.yml')) : {}
+      end
 
       def binary_exists?
         !Phare.system_output('which rubocop').empty?

--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -22,6 +22,10 @@ module Phare
 
     protected
 
+      def excluded_files
+        [] # TODO: Fetch the exclude list from .scss-lint.yml
+      end
+
       def binary_exists?
         !Phare.system_output('which scss-lint').empty?
       end


### PR DESCRIPTION
This add support for excluded files from `.rubocop.yml` config file. This is a first step, I've not added tests since adding the same feature for `scss`, `jscs` and `jshint` will probably end up in a small refactoring.

I've add a spec once it will be completed. Also, I plan on removing the hardcoded `.rubocop.yml` path later.

*Update: I'm merging in `feature/exclude-config-diff` for now.*