### PR TITLE
Add support for exclude list for jshint, jscs and scss-lint

### DIFF
--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -15,7 +15,7 @@ module Phare
 
       def command
         if @tree.changed?
-          "jscs #{@tree.changes.join(' ')}"
+          "jscs #{files_to_check.join(' ')}"
         else
           "jscs #{@path}"
         end
@@ -24,7 +24,13 @@ module Phare
     protected
 
       def excluded_files
-        [] # TODO: Fetch the exclude list from .jscs.json
+        return [] unless configuration_file['excludeFiles']
+
+        configuration_file['excludeFiles'].flat_map { |path| Dir.glob(path) }
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.jscs.json') ? JSON.parse(File.open('.jscs.json')) : {}
       end
 
       def binary_exists?

--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -16,7 +16,7 @@ module Phare
 
       def command
         if @tree.changed?
-          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@tree.changes.join(' ')}"
+          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{files_to_check.join(' ')}"
         else
           "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@glob}"
         end
@@ -25,7 +25,13 @@ module Phare
     protected
 
       def excluded_files
-        [] # TODO: Fetch the exclude list from .jshintignore
+        return [] unless configuration_file
+
+        configuration_file.split("\n").flat_map { |path| Dir.glob(path) }
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.jshintignore') ? File.open('.jshintignore') : false
       end
 
       def binary_exists?

--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -14,7 +14,7 @@ module Phare
 
       def command
         if @tree.changed?
-          "scss-lint #{@tree.changes.join(' ')}"
+          "scss-lint #{files_to_check.join(' ')}"
         else
           "scss-lint #{@path}"
         end
@@ -23,7 +23,13 @@ module Phare
     protected
 
       def excluded_files
-        [] # TODO: Fetch the exclude list from .scss-lint.yml
+        return [] unless configuration_file['exclude']
+
+        configuration_file['exclude'].flat_map { |path| Dir.glob(path) }
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.scss-lint.yml') ? YAML::load(File.open('.scss-lint.yml')) : {}
       end
 
       def binary_exists?


### PR DESCRIPTION
This adds support for the 3 other checks that we have: `jshint`, `jscs` and `scss-lint`. This is still at the prototype stage so again, there is no spec and it needs refactoring.

It will be the next step.

As you can notice, there is a lot of repetition. It will be fun to DRY :)