### PR TITLE
Prevent running check if all files are in the exclude list

### DIFF
--- a/lib/phare/check.rb
+++ b/lib/phare/check.rb
@@ -32,7 +32,10 @@ module Phare
       end
 
       if @options[:diff]
-        should_run &&= @tree.changed?
+        # NOTE: If the tree hasn't changed or if there is no files
+        #       to check (e.g. they are all in the exclude list),
+        #       we skip the check.
+        should_run &&= @tree.changed? && files_to_check.any?
       end
 
       should_run
@@ -41,7 +44,7 @@ module Phare
   protected
 
     def files_to_check
-      @tree.changes - excluded_files
+      @files_to_check ||= @tree.changes - excluded_files
     end
 
     def print_success_message


### PR DESCRIPTION
If all staged files are part of the exclude list, we were passing an empty list of files to check. `scss-lint` was not happy about it.

```
------------------------------------------
Running SCSS-Lint to check for SCSS style…
------------------------------------------
No SCSS files specified
Something went wrong. Program exited with 66.

------------------------------------------------------------------------
Something’s wrong with your code style. Please fix it before committing.
------------------------------------------------------------------------
```

So, if there is no files to check, we prevent the check from running.