### PR TITLE
Fix issue with scss-lint and its exclude setting

### DIFF
--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -25,7 +25,7 @@ module Phare
       def excluded_files
         return [] unless configuration_file['exclude']
 
-        configuration_file['exclude'].flat_map { |path| Dir.glob(path) }
+        [Dir.glob(configuration_file['exclude'])].flatten
       end
 
       def configuration_file


### PR DESCRIPTION
Sometimes, the `.scss-lint.yml` file can looks like this:

```
exclude: path/to/excluded_file.scss

...
```

And other times, it looks like this:

```
exclude:
  - path/to/excluded_file_one.scss
  - path/to/excluded_file_two.scss

...
```

This will be cleaned up in the upcoming refactor.