### PR TITLE
Fix issue with JSCS check missing JSON

### DIFF
--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -1,4 +1,7 @@
 # encoding: utf-8
+
+require 'json'
+
 module Phare
   class Check
     class JSCS < Check


### PR DESCRIPTION
JSCS check was raising a `uninitialized constant Phare::Check::JSCS::JSON (NameError)` when running. This should fix it.