### PR TITLE
Fix issue with JSCS config parsing

### DIFF
--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -33,7 +33,7 @@ module Phare
       end
 
       def configuration_file
-        @configuration_file ||= File.exist?('.jscs.json') ? JSON.parse(File.open('.jscs.json')) : {}
+        @configuration_file ||= File.exist?('.jscs.json') ? JSON.parse(File.read('.jscs.json')) : {}
       end
 
       def binary_exists?


### PR DESCRIPTION
We were enable to parse the `File.open` output with `JSON.parse`. It requires a `String` so `File.read` is much more appropriate.