### PR TITLE
Improve --diff option with exclude list

### DIFF
--- a/lib/phare/check.rb
+++ b/lib/phare/check.rb
@@ -32,13 +32,24 @@ module Phare
       end
 
       if @options[:diff]
-        should_run &&= @tree.changed?
+        # NOTE: If the tree hasn't changed or if there is no files
+        #       to check (e.g. they are all in the exclude list),
+        #       we skip the check.
+        should_run &&= @tree.changed? && files_to_check.any?
       end
 
       should_run
     end
 
   protected
+
+    def excluded_files
+      @excluded_files ||= [Dir.glob(excluded_list || [])].flatten
+    end
+
+    def files_to_check
+      @files_to_check ||= @tree.changes - excluded_files
+    end
 
     def print_success_message
       Phare.puts('Everything looks good from here!')

--- a/lib/phare/check/jscs.rb
+++ b/lib/phare/check/jscs.rb
@@ -1,4 +1,7 @@
 # encoding: utf-8
+
+require 'json'
+
 module Phare
   class Check
     class JSCS < Check
@@ -15,13 +18,21 @@ module Phare
 
       def command
         if @tree.changed?
-          "jscs #{@tree.changes.join(' ')}"
+          "jscs #{files_to_check.join(' ')}"
         else
           "jscs #{@path}"
         end
       end
 
     protected
+
+      def excluded_list
+        configuration_file['excludeFiles']
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.jscs.json') ? JSON.parse(File.read('.jscs.json')) : {}
+      end
 
       def binary_exists?
         !Phare.system_output('which jscs').empty?

--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -16,13 +16,21 @@ module Phare
 
       def command
         if @tree.changed?
-          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@tree.changes.join(' ')}"
+          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{files_to_check.join(' ')}"
         else
           "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@glob}"
         end
       end
 
     protected
+
+      def excluded_list
+        configuration_file.split("\n") if configuration_file
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.jshintignore') ? File.open('.jshintignore') : false
+      end
 
       def binary_exists?
         !Phare.system_output('which jshint').empty?

--- a/lib/phare/check/rubocop.rb
+++ b/lib/phare/check/rubocop.rb
@@ -12,13 +12,21 @@ module Phare
 
       def command
         if @tree.changed?
-          "rubocop #{@tree.changes.join(' ')}"
+          "rubocop #{files_to_check.join(' ')}"
         else
           'rubocop'
         end
       end
 
     protected
+
+      def excluded_list
+        configuration_file['AllCops']['Exclude'] if configuration_file['AllCops'] && configuration_file['AllCops']['Exclude']
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.rubocop.yml') ? YAML::load(File.open('.rubocop.yml')) : {}
+      end
 
       def binary_exists?
         !Phare.system_output('which rubocop').empty?

--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -14,13 +14,21 @@ module Phare
 
       def command
         if @tree.changed?
-          "scss-lint #{@tree.changes.join(' ')}"
+          "scss-lint #{files_to_check.join(' ')}"
         else
           "scss-lint #{@path}"
         end
       end
 
     protected
+
+      def excluded_list
+        configuration_file['exclude']
+      end
+
+      def configuration_file
+        @configuration_file ||= File.exist?('.scss-lint.yml') ? YAML::load(File.open('.scss-lint.yml')) : {}
+      end
 
       def binary_exists?
         !Phare.system_output('which scss-lint').empty?


### PR DESCRIPTION
We've been testing this for about a month now in our real development workflow. I think we can safely merge this and bump version to `0.7`.

We are now respecting the *exclude lists* from each check configuration file so the `--diff` option is far more usable now.