### PR TITLE
Bump version to 0.7

### DIFF
--- a/lib/phare/version.rb
+++ b/lib/phare/version.rb
@@ -1,3 +1,3 @@
 module Phare
-  VERSION = '0.6'
+  VERSION = '0.7'
 end


### PR DESCRIPTION
Included in release `0.7`:

* Add --version flag 
* Support “SKIP_PHARE” environment variable
* Improve `--diff` flag by only scanning staged files
* Improve `--diff` flag with exclude list
* Update Rubocop to `0.27`