### PR TITLE
Directory command argument was processed as boolean instead of string

### DIFF
--- a/lib/phare/cli.rb
+++ b/lib/phare/cli.rb
@@ -51,7 +51,7 @@ module Phare
           options_to_merge[:version] = true
         end
 
-        opts.on('--directory', 'The directory in which to run the checks (default is the current directory') do |directory|
+        opts.on('--directory x', 'The directory in which to run the checks (default is the current directory') do |directory|
           options_to_merge[:directory] = directory
         end
 


### PR DESCRIPTION
When using Phare with directory argument was processed as a boolean instead of string. 

This made phare crash on app initialization when passing the directory argument.

See output below. I added a puts to show the arg value.

Bug reported on commit bb9350a8fe45586fad27b52e4c93004eb761eb5f
Runtime environment : jruby 1.7.18 (1.9.3p551) 2014-12-22 625381c on Java HotSpot(TM) 64-Bit Server VM 1.8.0_25-b17 +jit [darwin-x86_64]

➜  phare git:(SHELLCHECK_BASH_LINTING) ✗ bin/phare --directory "~/prog/saga/iotheatre-raspberry/"
{:directory=>true}
NoMethodError: undefined method `end_with?' for true:TrueClass
  initialize at /Users/ddrmanxbxfr/prog/mirego/phare/lib/phare/check_suite.rb:17
  initialize at /Users/ddrmanxbxfr/prog/mirego/phare/lib/phare/cli.rb:10
      (root) at bin/phare:7

Thanks for looking into it.

Have a great day.