### PR TITLE
Fix issue with .jshintignore

### DIFF
--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -29,7 +29,7 @@ module Phare
       end
 
       def configuration_file
-        @configuration_file ||= File.exist?('.jshintignore') ? File.open('.jshintignore') : false
+        @configuration_file ||= File.exist?('.jshintignore') ? File.read('.jshintignore') : false
       end
 
       def binary_exists?


### PR DESCRIPTION
This fixes the following issue when running `jshint`:

```
`excluded_list': undefined method `split' for #<File:.jshintignore> (NoMethodError)
```

![](http://gifsec.com/wp-content/uploads/GIF/2014/06/my-bad-gifs.gif)