### PR TITLE
Remove path assumptions in SCSS check

### DIFF
--- a/lib/phare/check/scss_lint.rb
+++ b/lib/phare/check/scss_lint.rb
@@ -2,10 +2,14 @@
 module Phare
   class Check
     class ScssLint < Check
+      # Constants
+      DEFAULT_PATH = 'app/assets/stylesheets'.freeze
+
+      # Accessors
       attr_reader :path
 
       def initialize(directory, options = {})
-        @path = File.expand_path("#{directory}app/assets/stylesheets", __FILE__)
+        @directory = directory
         @extensions = %w(.scss)
         @options = options
 
@@ -16,11 +20,27 @@ module Phare
         if @tree.changed?
           "scss-lint #{files_to_check.join(' ')}"
         else
-          "scss-lint #{@path}"
+          "scss-lint #{expanded_path}"
         end
       end
 
     protected
+
+      def expanded_path
+        File.expand_path(@directory + path, __FILE__)
+      end
+
+      def path
+        scss_files = configuration_file['scss_files']
+
+        return DEFAULT_PATH unless scss_files
+
+        if scss_files.respond_to?(:join)
+          scss_files.join(' ')
+        else
+          scss_files
+        end
+      end
 
       def excluded_list
         configuration_file['exclude']
@@ -35,7 +55,7 @@ module Phare
       end
 
       def arguments_exists?
-        @tree.changed? || Dir.exist?(@path)
+        @tree.changed? || Dir.exist?(expanded_path)
       end
 
       def print_banner

--- a/spec/phare/check/scss_lint_spec.rb
+++ b/spec/phare/check/scss_lint_spec.rb
@@ -5,9 +5,10 @@ describe Phare::Check::ScssLint do
 
   describe :should_run? do
     let(:check) { described_class.new('.') }
+
     before do
       expect(Phare).to receive(:system_output).with('which scss-lint').and_return(which_output)
-      allow(Dir).to receive(:exist?).with(check.path).and_return(path_exists?)
+      allow(Dir).to receive(:exist?).with(check.send(:expanded_path)).and_return(path_exists?)
     end
 
     context 'with found scss-lint command' do
@@ -32,6 +33,34 @@ describe Phare::Check::ScssLint do
       let(:which_output) { '' }
       let(:path_exists?) { false }
       it { expect(check).to_not be_able_to_run }
+    end
+  end
+
+  describe :path do
+    let(:check) { described_class.new('.') }
+
+    before { expect(check).to receive(:configuration_file).and_return(configuration) }
+
+    context 'with `scss_files` specified' do
+      let(:configuration) { { 'scss_files' => scss_files } }
+
+      context 'as a String' do
+        let(:scss_files) { 'src/stylesheets/**/*.scss' }
+
+        it { expect(check.send(:path)).to eql(scss_files) }
+      end
+
+      context 'as an Array' do
+        let(:scss_files) { ['src/stylesheets/**/*.scss', 'vendor/**/*.scss'] }
+
+        it { expect(check.send(:path)).to eql(scss_files.join(' ')) }
+      end
+    end
+
+    context 'without `scss_files` specified' do
+      let(:configuration) { {} }
+
+      it { expect(check.send(:path)).to eql(Phare::Check::ScssLint::DEFAULT_PATH) }
     end
   end
 


### PR DESCRIPTION
We had the assumptions that SCSS check should happen in `./app/assets/stylesheets/`. This might not always be the case since we can specify the `scss_files` location in `.scss-lint.yml`.

I'll do the same for the other check. I'm merging in `feature/path-config`.