### PR TITLE
Remove hardcoded path for JSHint

### DIFF
--- a/lib/phare/check/jshint.rb
+++ b/lib/phare/check/jshint.rb
@@ -6,8 +6,7 @@ module Phare
 
       def initialize(directory, options = {})
         @config = File.expand_path("#{directory}.jshintrc", __FILE__)
-        @path = File.expand_path("#{directory}app/assets/javascripts", __FILE__)
-        @glob = File.join(@path, '**/*')
+        @path = '.'
         @extensions = %w(.js .es6)
         @options = options
 
@@ -16,9 +15,9 @@ module Phare
 
       def command
         if @tree.changed?
-          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{files_to_check.join(' ')}"
+          "jshint --extra-ext #{@extensions.join(',')} #{files_to_check.join(' ')}"
         else
-          "jshint --config #{@config} --extra-ext #{@extensions.join(',')} #{@glob}"
+          "jshint --extra-ext #{@extensions.join(',')} #{@path}"
         end
       end
 


### PR DESCRIPTION
We don't need to specify a folder for `JSHint` other that the current directory. Instead, we should specify folders we don't want to lint in the `.jshintignore` file.

I've tested with old project and it works like a charm. Also, by running `JSHint` in the current directory, we don't need to specify the configuration file.

I'm not sure but I think this also can fix the issue #11 reported by @charlesdemers.
