### PR TITLE
Add eslint check

### DIFF
--- a/lib/phare.rb
+++ b/lib/phare.rb
@@ -12,6 +12,7 @@ require 'phare/check/scss_lint'
 require 'phare/check/stylelint'
 require 'phare/check/jshint'
 require 'phare/check/jscs'
+require 'phare/check/eslint'
 
 require 'phare/check_suite'
 

--- a/lib/phare/check/eslint.rb
+++ b/lib/phare/check/eslint.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+module Phare
+  class Check
+    class Eslint < Check
+      GLOBAL_BINARY = 'eslint'.freeze
+      LOCAL_BINARY = 'node_modules/.bin/eslint'.freeze
+
+      attr_reader :config, :path
+
+      def initialize(directory, options = {})
+        @directory = directory
+        @config = File.expand_path("#{directory}.eslintrc", __FILE__)
+        @path = File.expand_path("#{directory}app/assets/javascripts", __FILE__)
+        @extensions = %w(.js)
+        @options = options
+
+        super
+      end
+
+      def command
+        "#{binary} #{input}"
+      end
+
+    protected
+
+      def configuration_exists?
+        File.exist?(@config)
+      end
+
+      def binary
+        local_binary_exists? ? @directory + LOCAL_BINARY : GLOBAL_BINARY
+      end
+
+      def binary_exists?
+        local_binary_exists? || global_binary_exists?
+      end
+
+      def local_binary_exists?
+        !Phare.system_output("which #{@directory}#{LOCAL_BINARY}").empty?
+      end
+
+      def global_binary_exists?
+        !Phare.system_output("which #{GLOBAL_BINARY}").empty?
+      end
+
+      def input
+        @tree.changed? ? files_to_check.join(' ') : "'#{@path}/**/*#{@extensions.first}'"
+      end
+
+      def arguments_exists?
+        @tree.changed? || Dir.exist?(@path)
+      end
+
+      def print_banner
+        Phare.banner 'Running ESLint to check for JavaScript style…'
+      end
+    end
+  end
+end

--- a/lib/phare/check_suite.rb
+++ b/lib/phare/check_suite.rb
@@ -7,7 +7,8 @@ module Phare
       scsslint: Check::ScssLint,
       stylelint: Check::Stylelint,
       jshint: Check::JSHint,
-      jscs: Check::JSCS
+      jscs: Check::JSCS,
+      eslint: Check::Eslint
     }
 
     def initialize(options = {})

--- a/spec/phare/check/eslint_spec.rb
+++ b/spec/phare/check/eslint_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+describe Phare::Check::Eslint do
+  let(:described_class) { Phare::Check::Eslint }
+
+  describe :should_run? do
+    let(:check) { described_class.new('.') }
+    let(:config_exists?) { true }
+    let(:path_exists?) { true }
+    let(:local_which_output) { '' }
+    let(:global_which_output) { '' }
+    before do
+      allow(Phare).to receive(:system_output).with('which eslint').and_return(global_which_output)
+      allow(Phare).to receive(:system_output).with('which .node_modules/.bin/eslint').and_return(local_which_output)
+      allow(File).to receive(:exist?).with(check.config).and_return(config_exists?)
+      allow(Dir).to receive(:exist?).with(check.path).and_return(path_exists?)
+    end
+
+    context 'with found eslint command' do
+      context 'for a local eslint' do
+        let(:local_which_output) { 'node_modules/.bin/eslint' }
+        it { expect(check).to be_able_to_run }
+      end
+
+      context 'for a global eslint' do
+        let(:global_which_output) { 'eslint' }
+        it { expect(check).to be_able_to_run }
+      end
+
+      context 'with only excluded files and the --diff option' do
+        let(:global_which_output) { 'eslint' }
+        let(:check) { described_class.new('.', diff: true) }
+        let(:files) { ['foo.js'] }
+
+        before do
+          expect(check).to receive(:excluded_files).and_return(files).once
+          expect(check.tree).to receive(:changes).and_return(files).at_least(:once)
+        end
+
+        it { expect(check.should_run?).to be_falsey }
+      end
+    end
+
+    context 'with unfound eslint command' do
+      let(:config_exists?) { false }
+      let(:path_exists?) { false }
+      it { expect(check).to_not be_able_to_run }
+    end
+  end
+
+  describe :run do
+    let(:check) { described_class.new('.') }
+    let(:run!) { check.run }
+
+    context 'with available Eslint' do
+      let(:command) { check.command }
+
+      before do
+        expect(check).to receive(:should_run?).and_return(true)
+        expect(Phare).to receive(:system).with(command)
+        expect(Phare).to receive(:last_exit_status).and_return(eslint_exit_status)
+        expect(check).to receive(:print_banner)
+      end
+
+      context 'without check errors' do
+        let(:eslint_exit_status) { 0 }
+        before { expect(Phare).to receive(:puts).with('Everything looks good from here!') }
+        it { expect { run! }.to change { check.status }.to(eslint_exit_status) }
+      end
+
+      context 'with check errors' do
+        let(:eslint_exit_status) { 1 }
+        before { expect(Phare).to receive(:puts).with("Something went wrong. Program exited with #{eslint_exit_status}.") }
+        it { expect { run! }.to change { check.status }.to(eslint_exit_status) }
+      end
+
+      context 'with --diff option' do
+        let(:check) { described_class.new('.', diff: true) }
+        let(:files) { ['foo.rb', 'bar.rb'] }
+        let(:eslint_exit_status) { 0 }
+
+        context 'without exclusions' do
+          let(:command) { "eslint #{files.join(' ')}" }
+
+          before do
+            expect(check.tree).to receive(:changes).and_return(files).at_least(:once)
+            expect(check).to receive(:excluded_files).and_return([]).once
+          end
+
+          it { expect { run! }.to change { check.status }.to(eslint_exit_status) }
+        end
+
+        context 'with exclusions' do
+          let(:command) { 'eslint bar.rb' }
+
+          before do
+            expect(check).to receive(:excluded_files).and_return(['foo.rb']).once
+            expect(check.tree).to receive(:changes).and_return(files).at_least(:once)
+          end
+
+          it { expect { run! }.to change { check.status }.to(eslint_exit_status) }
+        end
+      end
+    end
+
+    context 'with unavailable Eslint' do
+      before do
+        expect(check).to receive(:should_run?).and_return(false)
+        expect(Phare).to_not receive(:system).with(check.command)
+        expect(check).to_not receive(:print_banner)
+      end
+
+      it { expect { run! }.to change { check.status }.to(0) }
+    end
+  end
+end

--- a/spec/phare/check_suite_spec.rb
+++ b/spec/phare/check_suite_spec.rb
@@ -50,7 +50,7 @@ describe Phare::CheckSuite do
     end
 
     context 'with "skip" option' do
-      let(:skip) { [:scsslint, :stylelint, :foo, :jshint] }
+      let(:skip) { [:scsslint, :stylelint, :foo, :jshint, :eslint] }
       it { expect(suite.checks).to eql [:rubocop, :jscs] }
     end
 


### PR DESCRIPTION
Add `ESLint` check with spec. This check will use a local `node_modules` eslint bin or verify if it can use a global bin for eslint.