### PR TITLE
Add excluded_list default value in Check class

### DIFF
--- a/lib/phare/check.rb
+++ b/lib/phare/check.rb
@@ -47,6 +47,10 @@ module Phare
       @excluded_files ||= [Dir.glob(excluded_list || [])].flatten
     end
 
+    def excluded_list
+      [] # Should be overriden by children
+    end
+
     def files_to_check
       @files_to_check ||= @tree.changes - excluded_files
     end

--- a/phare.gemspec
+++ b/phare.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.0.0.rc1'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop', '0.27'
 end


### PR DESCRIPTION
When using the `1.0.0` version on a project with javascript files, I got the following error:

```
/Users/garno/.asdf/installs/ruby/2.3.1/lib/ruby/gems/2.3.0/gems/phare-1.0.0/lib/phare/check.rb:47:in
`excluded_files': undefined local variable or method `excluded_list' for #<Phare::Check::Eslint:0x007fc542c44938> (NameError)
```

`excluded_list` was missing from `Eslint` and `Stylelint`. In the future, we might want to implement them.