### PR TITLE
Update Ruby version with the latests for Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.1.1
-  - 2.0.0
+  - 2.3.1
+  - 2.2
+  - 2.1
+  - 2.0
 
 script:
   - 'echo "Checking code style" && ./bin/phare'


### PR DESCRIPTION
I've updated the Ruby version this gem is tested with and added `2.3.1` and `2.2.6`. The gem is not working on Travis with version above `2.3.1` since `rainbow` gem can't be installed.

It's working well in local, I'll investigate later.